### PR TITLE
docs: Dead links and systemctl

### DIFF
--- a/docs/component-info/hardware.md
+++ b/docs/component-info/hardware.md
@@ -69,7 +69,7 @@ If no disk is passed, the script will attempt to detect one which is available.
 Run `./provision.sh --help` for all options.
 
 [provision]: https://github.com/liquidmetal-dev/flintlock/tree/main/hack/scripts#provisionsh
-[fc]: https://github.com/weaveworks/firecracker/releases
+[fc]: https://github.com/firecracker-microvm/firecracker/releases
 [flint]: https://github.com/liquidmetal-dev/flintlock/releases
 [service]: https://github.com/liquidmetal-dev/flintlock/blob/main/flintlockd.service
 [containerd]: https://github.com/containerd/containerd/releases

--- a/docs/troubleshooting/containerd.md
+++ b/docs/troubleshooting/containerd.md
@@ -7,7 +7,7 @@ Understanding common `containerd` errors.
 Containerd logs can be watched by running:
 
 ```bash
-journatctl -fu containerd.service
+journalctl -fu containerd.service
 ```
 
 After creating MicroVMs, use `ctr` to inspect artifacts:

--- a/docs/troubleshooting/flintlock.md
+++ b/docs/troubleshooting/flintlock.md
@@ -11,7 +11,7 @@ all.
 Flintlock logs can be watched by running:
 
 ```bash
-journatctl -fu flintlockd.service
+journalctl -fu flintlockd.service
 ```
 
 ### Snapshotter not loaded

--- a/docs/tutorial-basics/containerd.md
+++ b/docs/tutorial-basics/containerd.md
@@ -10,7 +10,7 @@ into MicroVMs as kernel and OS volumes.
 Download the all-in-one provision script:
 
 ```bash
-wget https://raw.githubusercontent.com/weaveworks-liquidmetal/flintlock/main/hack/scripts/provision.sh
+wget https://raw.githubusercontent.com/liquidmetal-dev/flintlock/main/hack/scripts/provision.sh
 chmod +x provision.sh
 ```
 

--- a/docs/tutorial-basics/macos.md
+++ b/docs/tutorial-basics/macos.md
@@ -21,7 +21,7 @@ Install both these tools, create a new working directory, and fetch the tutorial
 ```bash
 mkdir lm-tutorial
 cd !$
-wget https://raw.githubusercontent.com/weaveworks-liquidmetal/flintlock/main/Vagrantfile
+wget https://raw.githubusercontent.com/liquidmetal-dev/flintlock/main/Vagrantfile
 ```
 
 Start the machine:

--- a/docs/tutorial-rpi/build-guide/host-bootstrapping.md
+++ b/docs/tutorial-rpi/build-guide/host-bootstrapping.md
@@ -57,7 +57,7 @@ reboot the Pi and try again afterwards.
 We will use a script to bootstrap the rest. Download it onto each board:
 
 ```bash
-wget https://raw.githubusercontent.com/weaveworks-liquidmetal/flintlock/main/hack/scripts/provision.sh
+wget https://raw.githubusercontent.com/liquidmetal-dev/flintlock/main/hack/scripts/provision.sh
 chmod +x provision.sh
 ```
 

--- a/src/pages/flintlock-api.js
+++ b/src/pages/flintlock-api.js
@@ -3,6 +3,6 @@ import { RedocStandalone } from 'redoc';
 
 export default function Hello() {
   return (
-    <RedocStandalone specUrl="https://raw.githubusercontent.com/weaveworks-liquidmetal/flintlock/main/api/services/microvm/v1alpha1/microvms.swagger.json"/>
+    <RedocStandalone specUrl="https://raw.githubusercontent.com/liquidmetal-dev/flintlock/main/api/services/microvm/v1alpha1/microvms.swagger.json"/>
   )
 }


### PR DESCRIPTION
Howdy,

I've updated some links and download scripts to point to the liquidmetal-dev org rather than the weaveworks archived repo.

Also it was **very** confusing for me looking at the docs because I didnt not realise until 5 minutes ago that the docs linked to from the liquidmetal repo is a completely different website with worse docs.

If you could update that to point to this that would cause allot less confusion.


Thank you very much :) 