### PR TITLE
fix: correct CAPMVM release URL path

### DIFF
--- a/docs/tutorial-basics/capi.md
+++ b/docs/tutorial-basics/capi.md
@@ -76,7 +76,7 @@ repo:
 cat << EOF >>~/.cluster-api/clusterctl.yaml
 providers:
   - name: "microvm"
-    url: "https://github.com/liquidmetal-dev/cluster-api-provider-microvm/releases/$CAPMVM_VERSION/infrastructure-components.yaml"
+    url: "https://github.com/liquidmetal-dev/cluster-api-provider-microvm/releases/download/$CAPMVM_VERSION/infrastructure-components.yaml"
     type: "InfrastructureProvider"
 EOF
 ```

--- a/docs/tutorial-equinix/capi.md
+++ b/docs/tutorial-equinix/capi.md
@@ -76,7 +76,7 @@ repo:
 cat << EOF >>~/.cluster-api/clusterctl.yaml
 providers:
   - name: "microvm"
-    url: "https://github.com/liquidmetal-dev/cluster-api-provider-microvm/releases/$CAPMVM_VERSION/infrastructure-components.yaml"
+    url: "https://github.com/liquidmetal-dev/cluster-api-provider-microvm/releases/download/$CAPMVM_VERSION/infrastructure-components.yaml"
     type: "InfrastructureProvider"
 EOF
 ```

--- a/docs/tutorial-rpi/build-guide/management-cluster.md
+++ b/docs/tutorial-rpi/build-guide/management-cluster.md
@@ -55,7 +55,7 @@ repo.
 cat << EOF >~/.cluster-api/clusterctl.yaml
 providers:
   - name: "microvm"
-    url: "https://github.com/liquidmetal-dev/cluster-api-provider-microvm/releases/$CAPMVM_VERSION/infrastructure-components.yaml"
+    url: "https://github.com/liquidmetal-dev/cluster-api-provider-microvm/releases/download/$CAPMVM_VERSION/infrastructure-components.yaml"
     type: "InfrastructureProvider"
 EOF
 ```


### PR DESCRIPTION
Add missing 'download' segment in GitHub release URLs for CAPMVM infrastructure components.

This fixes the incorrect path across all tutorial documentation files.